### PR TITLE
Add translator for app's strings

### DIFF
--- a/lang/default.ini
+++ b/lang/default.ini
@@ -1,0 +1,5 @@
+[Form]
+new_entry = "New entry: %s"
+
+[RequiredValidator]
+required_field = Required field

--- a/lang/fi.ini
+++ b/lang/fi.ini
@@ -1,0 +1,5 @@
+[Form]
+new_entry = "Lomake lähetetty: %s"
+
+[RequiredValidator]
+required_field = Pakollinen tieto

--- a/src/Form.php
+++ b/src/Form.php
@@ -47,7 +47,9 @@ class Form {
         $this->send_to = $json->sendto;
 
         // set optional properties
-        $this->lang = property_exists($json, "lang") ? $json->lang : "";
+        $this->lang = property_exists($json, "lang") ? $json->lang : "default";
+        $translator = Translator::getInstance();
+        $translator->setLanguage($this->lang);
 
         $this->fields = array();
         foreach($json->fields as $field)
@@ -133,10 +135,14 @@ class Form {
         $plaintext = "";
         $html_section = new TagFactory("section");
 
-        $header_text = "New entry: " . $this->form_title;
+        $translator = Translator::getInstance();
+        $new_entry_string = sprintf($translator->text("Form.new_entry"),
+            $this->form_title);
+
+        $header_text = $new_entry_string;
         $plaintext .= $header_text."\r\n\r\n";
         $html_header = new TagFactory("h1");
-        $html_header->addChild(new TextElement("New entry: " . $this->form_title));
+        $html_header->addChild(new TextElement($new_entry_string));
         $html_section->addChild($html_header);
 
         foreach($this->fields as $field)

--- a/src/RequiredValidator.php
+++ b/src/RequiredValidator.php
@@ -24,7 +24,8 @@ class RequiredValidator extends Validator
 
     public function getErrorString(): string
     {
-        return "Required field";
+        $translator = Translator::getInstance();
+        return $translator->text("RequiredValidator.required_field");
     }
 }
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -1,0 +1,93 @@
+<?php
+
+/*!
+ * Provides strings in the requested language. Looks string up from .ini files
+ * in the lang/ directory. If a translated string is not available, outputs the
+ * string in the default language (lang/default.ini).
+ */
+class Translator
+{
+    private static $instance = null;
+    private array $strings;
+
+    /*!
+     * This class doesn't really need a constructor, but one is defined as
+     * private in order to make it a singleton
+     */
+    private function __construct() {}
+
+    /*!
+     * Returns the instance of this singleton class.
+     */
+    public static function getInstance()
+    {
+        if(self::$instance == null)
+        {
+            self::$instance = new Translator();
+        }
+        return self::$instance;
+    }
+
+    /*!
+     * Reads translated strings from a translation file.
+     * 
+     * @param $lang the language code for the desired language. A file named
+     * $lang.ini must be found in the lang directory of the app.
+     */
+    public function setLanguage(string $lang)
+    {
+        $default_strings = parse_ini_file("lang/default.ini", true);
+        $strings = parse_ini_file("lang/".$lang.".ini", true);
+        if($strings === false)
+        {
+            trigger_error("Language file for ". $lang ." was not found." .
+                " Using default language.", E_USER_NOTICE);
+            $strings = array();
+        }
+
+        $default_strings = $this->unrollIniSections($default_strings);
+        $strings = $this->unrollIniSections($strings);
+
+        /* The order of arguments for array_merge() is important in this case
+        because we want values of default.ini to appear ONLY where $lang.ini
+        does not set them */
+        $this->strings = array_merge($default_strings, $strings);
+    }
+
+    /*!
+     * Convert the multidimensional sectioned arrays returned by parse_ini_file
+     * into single-dimensional arrays with keys of the form $section.$key
+     */
+    private function unrollIniSections($sections): array
+    {
+        $retArr = array();
+        foreach($sections as $section => $keyvalues)
+        {
+            foreach ($keyvalues as $key => $value)
+            {
+                $newkey = $section.".".$key;
+                $retArr += array($newkey => $value);
+            }
+        }
+        return $retArr;
+    }
+
+    /*!
+     * @returns the string associated with a specific @param $key located in a
+     * specific @param $section.
+     */
+    public function text($key)
+    {
+        if(!isset($this->strings))
+        {
+            trigger_error("Translated string ".$section.".".$key.
+                " was requested before a language was set. Using default ".
+                "language", E_USER_NOTICE);
+            $this->setLanguage("default");
+        }
+
+        return $this->strings[$key];
+    }
+}
+
+?>


### PR DESCRIPTION
A simple translation system based on ini files. User specifies a language to be used with their forms in the form JSON file, e.g. `"lang": "fi"`. The translator service then looks up a file named accordingly, in the case of the example, `lang/fi.ini`file and reads the translation strings. Resolves #2 

For missing translations, the translator class gives values from the default.ini file.

For a missing language, a notice is thrown, and strings are read from default.ini

Todo:
- [x] Update wiki to reflect functionality