### PR TITLE
Create a basic unit test framework

### DIFF
--- a/tests/TestRequiredValidator.php
+++ b/tests/TestRequiredValidator.php
@@ -1,0 +1,21 @@
+<?php
+/*!
+ * Run all unit tests. When a new test file is added, add a call in this file.
+ */
+
+try
+{
+    $required_validator = new RequiredValidator("invalid");
+} catch(Exception $e) {}
+
+assert(!isset($required_validator));
+
+$required_validator = new RequiredValidator("required");
+assert($required_validator instanceof RequiredValidator);
+assert($required_validator->isValid(null) == false);
+assert($required_validator->isValid("") == false);
+assert($required_validator->isValid(" ") == false);
+assert($required_validator->isValid(125));
+assert($required_validator->isValid("This is a string."));
+
+?>

--- a/tests/TestRequiredValidator.php
+++ b/tests/TestRequiredValidator.php
@@ -1,7 +1,4 @@
 <?php
-/*!
- * Run all unit tests. When a new test file is added, add a call in this file.
- */
 
 try
 {

--- a/tests/run_all.php
+++ b/tests/run_all.php
@@ -1,0 +1,17 @@
+<?php
+/*!
+ * Run all unit tests. When a new test file is added, add a call in this file.
+ */
+
+spl_autoload_register(function ($class_name) {
+    $try1 = "src/" . $class_name . '.php';
+    $try2 = $class_name . '.php';
+    if(file_exists($try1))
+        include $try1;
+    else
+        include $try2;
+});
+
+include('TestRequiredValidator.php');
+
+?>


### PR DESCRIPTION
Simple framework for doing unit tests. Originally written to expedite writing validators. `tests/TestRequiredValidator`is added as a test and an example.

To run the tests, run `php tests/run_all.php`from the main directory. If nothing is returned to the terminal window, all tests passed.