### PR TITLE
Feature/honeypots

### DIFF
--- a/forms/default.json
+++ b/forms/default.json
@@ -12,6 +12,11 @@
       "type": "html"
     },
     {
+      "name": "title",
+      "label": "Title",
+      "type": "honeypot"
+    },
+    {
       "name": "name",
       "label": "Your Name",
       "type": "input",

--- a/src/Form.php
+++ b/src/Form.php
@@ -7,6 +7,7 @@ require_once("TCheckFields.php");
  */
 class Form {
     use CheckFields;
+    use HoneypotCSS;
 
     private string $form_title;
     private string $form_template;
@@ -82,6 +83,7 @@ class Form {
         $tpl->loadTemplate("./templates/".$this->form_template);
         $tpl->registerVariable("form_title", $this->form_title);
         $tpl->registerVariable("form_css", file_get_contents("./static/default.css"));
+        $tpl->registerVariable("honeypot_css", Form::generateHoneypotCSS());
         $tpl->registerVariable("form", $formTag->makeHTML());
 
         return $tpl->output();

--- a/src/FormField.php
+++ b/src/FormField.php
@@ -199,6 +199,10 @@ class FormField {
             case 'datalist':
                 return new SelectField($obj);
                 break;
+
+            case 'honeypot':
+                return new HoneypotField($obj);
+                break;
                 
             case 'button':
             case 'output':

--- a/src/HoneypotCSS.php
+++ b/src/HoneypotCSS.php
@@ -1,0 +1,42 @@
+<?php
+
+trait HoneypotCSS
+{
+	/*!
+	 * Generate a CSS class name to be used for hiding honeypot fields from
+	 * regular users
+	 */
+	public function generateHoneypotClassName(): string
+	{
+		$honeypot_class = base64_encode("honeypot-".$_SERVER['PHP_SELF']);
+        $honeypot_class = preg_replace("/[^a-zA-Z]/", "", $honeypot_class);
+        $honeypot_class = strtolower($honeypot_class);
+        $honeypot_class = substr($honeypot_class, 0, 6);
+
+        return $honeypot_class;
+	}
+
+	public function generateHoneypotCSS(): string
+	{
+		$css_lines = array(
+			"opacity: 0;",
+        	"position: absolute;",
+        	"top: 0;",
+        	"left: 0;",
+        	"height: 0;",
+        	"width: 0;",
+        	"z-index: -1;"
+		);
+		shuffle($css_lines);
+		$css  = ".".$this::generateHoneypotClassName()."\n";
+		$css .= "{\n";
+		foreach($css_lines as $line)
+		{
+			$css .= "  ".$line."\n";
+		}
+		$css .= "}\n";
+
+		return $css;
+	}
+}
+?>

--- a/src/HoneypotField.php
+++ b/src/HoneypotField.php
@@ -1,0 +1,77 @@
+<?php
+
+/*! Implements a honeypot field in the form. Spam bots are expected to fill in
+ * every field they find on the form (especially if it has a luring name and)
+ * value. A honeypot field is hidden (by CSS) from real users, so they do not
+ * fill the field in. If anything is found in the value for this field, a spam
+ * bot is deemed to have filled it.
+ *  The honeypot field also disregards any validators it may have added to it.
+ * All it cares about is whether or not it has anything in its value, and if
+ * so, it blocks further processing of the form.
+ */
+class HoneypotField extends InputField
+{
+	public function __construct(object $obj)
+	{
+		$this->name = $obj->name;
+        $this->label = $obj->label;
+        $this->type = $obj->type;
+	}
+
+	/*!
+	 * Make the field HTML just as if this was a regular form field. Sneak in
+	 * a special CSS class to hide the form field.
+	 */
+	public function makeField(): TagFactory
+    {
+        $field_id = "field_".$this->name;
+        $honeypot_class = base64_encode("honeypot-".$_SERVER['PHP_SELF']);
+        $honeypot_class = preg_replace("/[^a-zA-Z]/", "", $honeypot_class);
+        $honeypot_class = strtolower($honeypot_class);
+        $honeypot_class = substr($honeypot_class, 0, 6);
+        
+        $field = new TagFactory("label", array(
+        	"for" => $field_id, "class" => $honeypot_class));
+        $field->addChild(new TextElement($this->label . ": "));
+        $field->addChild(new TagFactory(
+            "input",
+            array(
+                "name" => $this->name,
+                "id" => $field_id,
+                "class" => $honeypot_class,
+            ), true
+        ));
+
+        return $field;
+    }
+
+    /*! HoneypotField is only ever interested in whether or not a value has
+     * been submitted or not. Therefore, instead of running any validators,
+     * we merely check if the field has values or not.
+     */
+    public function validate(): bool
+    {
+    	if(isset($_POST[$this->name]) && !empty($_POST[$this->name]))
+    		return false;
+
+    	return true;
+    }
+
+    /*!
+     * Honeypots shouldn't display anything as returned values. Return an empty
+     * span element.
+     */
+    public function makeFieldResponseHTML(): TagFactory
+    {
+    	return new TagFactory("span");
+    }
+
+    /*!
+     * Return an empty string, as honeypots have no user-submitted data to show
+     */
+    public function makeFieldResponsePlain(): string
+    {
+    	return "";
+    }
+}
+?>

--- a/src/HoneypotField.php
+++ b/src/HoneypotField.php
@@ -11,6 +11,8 @@
  */
 class HoneypotField extends InputField
 {
+    use HoneypotCSS;
+    
 	public function __construct(object $obj)
 	{
 		$this->name = $obj->name;
@@ -25,10 +27,7 @@ class HoneypotField extends InputField
 	public function makeField(): TagFactory
     {
         $field_id = "field_".$this->name;
-        $honeypot_class = base64_encode("honeypot-".$_SERVER['PHP_SELF']);
-        $honeypot_class = preg_replace("/[^a-zA-Z]/", "", $honeypot_class);
-        $honeypot_class = strtolower($honeypot_class);
-        $honeypot_class = substr($honeypot_class, 0, 6);
+        $honeypot_class = HoneypotField::generateHoneypotClassName();
         
         $field = new TagFactory("label", array(
         	"for" => $field_id, "class" => $honeypot_class));

--- a/templates/form.html
+++ b/templates/form.html
@@ -9,6 +9,7 @@
 
   <style type="text/css">
     {{ form_css }}
+    {{ honeypot_css  }}
   </style>
 
 </head>


### PR DESCRIPTION
Adds honeypot fields to forms when requested in the form JSON.
- Assigns a random CSS class name for honeypots
- Shuffles the order of the lines in the CSS to avoid detection
- Form JSON is allowed to set field names and labels just as if the field was a regular form field. This allows the honeypot to hide better.

Implements #16 